### PR TITLE
Set arrow-parens to always required

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -21,7 +21,7 @@ module.exports = {
         'no-sync': 'error',
 
         'arrow-body-style': 'off',
-        'arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
+        'arrow-parens': 'error',
         'arrow-spacing': 'error',
         'constructor-super': 'error',
         'generator-star-spacing': 'error',


### PR DESCRIPTION
It's a real pain in the butt to add and remove `()` as you add, change and remove parameters to arrow functions. Just to simplify things, I think `()` should always be required. Less mucking around.

This PR makes that change.
